### PR TITLE
ath9k_htc: enable dynack debug output

### DIFF
--- a/drivers/net/wireless/ath/ath9k/common-debug.c
+++ b/drivers/net/wireless/ath/ath9k/common-debug.c
@@ -258,3 +258,33 @@ void ath9k_cmn_debug_phy_err(struct dentry *debugfs_phy,
 			    &fops_phy_err);
 }
 EXPORT_SYMBOL(ath9k_cmn_debug_phy_err);
+
+#ifdef CONFIG_ATH9K_DYNACK
+static ssize_t read_file_ackto(struct file *file, char __user *user_buf,
+			       size_t count, loff_t *ppos)
+{
+	struct ath_hw *ah = file->private_data;
+	char buf[32];
+	unsigned int len;
+
+	len = sprintf(buf, "%u %c\n", ah->dynack.ackto,
+		      (ah->dynack.enabled) ? 'A' : 'S');
+
+	return simple_read_from_buffer(user_buf, count, ppos, buf, len);
+}
+
+static const struct file_operations fops_ackto = {
+	.read = read_file_ackto,
+	.open = simple_open,
+	.owner = THIS_MODULE,
+	.llseek = default_llseek,
+};
+
+void ath9k_cmn_debug_ack_to(struct dentry *debugfs_phy,
+			    struct ath_hw *ah)
+{
+	debugfs_create_file("ack_to", 0400, debugfs_phy, ah, &fops_ackto);
+}
+EXPORT_SYMBOL(ath9k_cmn_debug_ack_to);
+
+#endif

--- a/drivers/net/wireless/ath/ath9k/common-debug.h
+++ b/drivers/net/wireless/ath/ath9k/common-debug.h
@@ -71,6 +71,8 @@ void ath9k_cmn_debug_recv(struct dentry *debugfs_phy,
 			  struct ath_rx_stats *rxstats);
 void ath9k_cmn_debug_phy_err(struct dentry *debugfs_phy,
 			     struct ath_rx_stats *rxstats);
+void ath9k_cmn_debug_ack_to(struct dentry *debugfs_phy,
+			    struct ath_hw *ah);
 #else
 static inline void ath9k_cmn_debug_modal_eeprom(struct dentry *debugfs_phy,
 						struct ath_hw *ah)
@@ -94,6 +96,10 @@ static inline void ath9k_cmn_debug_recv(struct dentry *debugfs_phy,
 
 static inline void ath9k_cmn_debug_phy_err(struct dentry *debugfs_phy,
 					   struct ath_rx_stats *rxstats)
+{
+}
+static inline void ath9k_cmn_debug_ack_to(struct dentry *debugfs_phy,
+					  struct ath_hw *ah);
 {
 }
 #endif /* CONFIG_ATH9K_COMMON_DEBUG */

--- a/drivers/net/wireless/ath/ath9k/debug.c
+++ b/drivers/net/wireless/ath/ath9k/debug.c
@@ -1038,29 +1038,6 @@ static const struct file_operations fops_btcoex = {
 };
 #endif
 
-#ifdef CONFIG_ATH9K_DYNACK
-static ssize_t read_file_ackto(struct file *file, char __user *user_buf,
-			       size_t count, loff_t *ppos)
-{
-	struct ath_softc *sc = file->private_data;
-	struct ath_hw *ah = sc->sc_ah;
-	char buf[32];
-	unsigned int len;
-
-	len = sprintf(buf, "%u %c\n", ah->dynack.ackto,
-		      (ah->dynack.enabled) ? 'A' : 'S');
-
-	return simple_read_from_buffer(user_buf, count, ppos, buf, len);
-}
-
-static const struct file_operations fops_ackto = {
-	.read = read_file_ackto,
-	.open = simple_open,
-	.owner = THIS_MODULE,
-	.llseek = default_llseek,
-};
-#endif
-
 #ifdef CONFIG_ATH9K_WOW
 
 static ssize_t read_file_wow(struct file *file, char __user *user_buf,
@@ -1451,9 +1428,9 @@ int ath9k_init_debug(struct ath_hw *ah)
 #endif
 
 #ifdef CONFIG_ATH9K_DYNACK
-	debugfs_create_file("ack_to", 0400, sc->debug.debugfs_phy,
-			    sc, &fops_ackto);
+	ath9k_cmn_debug_ack_to(sc->debug.debugfs_phy, sc->sc_ah);
 #endif
+	
 	debugfs_create_file("tpc", 0600, sc->debug.debugfs_phy, sc, &fops_tpc);
 
 	debugfs_create_u16("airtime_flags", 0600,

--- a/drivers/net/wireless/ath/ath9k/htc_drv_debug.c
+++ b/drivers/net/wireless/ath/ath9k/htc_drv_debug.c
@@ -520,7 +520,7 @@ int ath9k_htc_init_debug(struct ath_hw *ah)
 	ath9k_cmn_debug_base_eeprom(priv->debug.debugfs_phy, priv->ah);
 	ath9k_cmn_debug_modal_eeprom(priv->debug.debugfs_phy, priv->ah);
 
-#ifdef CPTCFG_ATH9K_DYNACK
+#ifdef CONFIG_ATH9K_DYNACK
 	ath9k_cmn_debug_ack_to(priv->debug.debugfs_phy, priv->ah);
 #endif
 

--- a/drivers/net/wireless/ath/ath9k/htc_drv_debug.c
+++ b/drivers/net/wireless/ath/ath9k/htc_drv_debug.c
@@ -520,5 +520,9 @@ int ath9k_htc_init_debug(struct ath_hw *ah)
 	ath9k_cmn_debug_base_eeprom(priv->debug.debugfs_phy, priv->ah);
 	ath9k_cmn_debug_modal_eeprom(priv->debug.debugfs_phy, priv->ah);
 
+#ifdef CPTCFG_ATH9K_DYNACK
+	ath9k_cmn_debug_ack_to(priv->debug.debugfs_phy, priv->ah);
+#endif
+
 	return 0;
 }


### PR DESCRIPTION
Move dynack debug code from debug.c to common-debug.c and adjust ath9k/ath9k_htc debug for common dynack output.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>