### PR TITLE
ath9k_htc:increase stations limit

### DIFF
--- a/drivers/net/wireless/ath/ath9k/htc.h
+++ b/drivers/net/wireless/ath/ath9k/htc.h
@@ -251,8 +251,8 @@ struct ath9k_vif_iter_data {
 	u8 mask[ETH_ALEN];
 };
 
-#define ATH9K_HTC_MAX_STA 8
-#define ATH9K_HTC_MAX_TID 8
+#define ATH9K_HTC_MAX_STA 128
+#define ATH9K_HTC_MAX_TID 16
 
 enum tid_aggr_state {
 	AGGR_STOP = 0,


### PR DESCRIPTION
The increase of stations limit eliminates problem of only 7-8 clients able to connect to an AP.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>