### PR TITLE
ath: enable 5/10 MHz width for ath9k/ath9k_htc

### DIFF
--- a/drivers/net/wireless/ath/ath.h
+++ b/drivers/net/wireless/ath/ath.h
@@ -149,6 +149,7 @@ struct ath_common {
 	int debug_mask;
 	enum ath_device_state state;
 	unsigned long op_flags;
+	u32 chan_bw;
 
 	struct ath_ani ani;
 

--- a/drivers/net/wireless/ath/ath9k/common.c
+++ b/drivers/net/wireless/ath/ath9k/common.c
@@ -297,11 +297,13 @@ EXPORT_SYMBOL(ath9k_cmn_get_hw_crypto_keytype);
 /*
  * Update internal channel flags.
  */
-static void ath9k_cmn_update_ichannel(struct ath9k_channel *ichan,
+static void ath9k_cmn_update_ichannel(struct ath_common *common,
+				      struct ath9k_channel *ichan,
 				      struct cfg80211_chan_def *chandef)
 {
 	struct ieee80211_channel *chan = chandef->chan;
 	u16 flags = 0;
+	int width;
 
 	ichan->channel = chan->center_freq;
 	ichan->chan = chan;
@@ -309,7 +311,19 @@ static void ath9k_cmn_update_ichannel(struct ath9k_channel *ichan,
 	if (chan->band == NL80211_BAND_5GHZ)
 		flags |= CHANNEL_5GHZ;
 
-	switch (chandef->width) {
+	switch (common->chan_bw) {
+	case 5:
+		width = NL80211_CHAN_WIDTH_5;
+		break;
+	case 10:
+		width = NL80211_CHAN_WIDTH_10;
+		break;
+	default:
+		width = chandef->width;
+		break;
+	}
+
+	switch (width) {
 	case NL80211_CHAN_WIDTH_5:
 		flags |= CHANNEL_QUARTER;
 		break;
@@ -342,10 +356,11 @@ struct ath9k_channel *ath9k_cmn_get_channel(struct ieee80211_hw *hw,
 					    struct cfg80211_chan_def *chandef)
 {
 	struct ieee80211_channel *curchan = chandef->chan;
+	struct ath_common *common = ath9k_hw_common(ah);
 	struct ath9k_channel *channel;
 
 	channel = &ah->channels[curchan->hw_value];
-	ath9k_cmn_update_ichannel(channel, chandef);
+	ath9k_cmn_update_ichannel(common, channel, chandef);
 
 	return channel;
 }

--- a/drivers/net/wireless/ath/ath9k/htc_drv_init.c
+++ b/drivers/net/wireless/ath/ath9k/htc_drv_init.c
@@ -750,9 +750,9 @@ static void ath9k_set_hw_capab(struct ath9k_htc_priv *priv,
 
 	hw->wiphy->flags |= WIPHY_FLAG_IBSS_RSN |
 			    WIPHY_FLAG_HAS_REMAIN_ON_CHANNEL |
-			    WIPHY_FLAG_HAS_CHANNEL_SWITCH;
-
-	hw->wiphy->flags |= WIPHY_FLAG_SUPPORTS_TDLS;
+			    WIPHY_FLAG_HAS_CHANNEL_SWITCH |
+			    WIPHY_FLAG_SUPPORTS_5_10_MHZ |
+			    WIPHY_FLAG_SUPPORTS_TDLS;
 
 	hw->queues = 4;
 	hw->max_listen_interval = 1;


### PR DESCRIPTION
This enables 5/10 MHz wide channels via debug file for both ath9k and ath9k_htc drivers. Connection tested and works in legacy and HT20 modes. This changeset is based on OpenWrt patch:  	512-ath9k_channelbw_debugfs.patch

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>