### PR TITLE
thermal: step_wise: Revert optimization

### DIFF
--- a/drivers/thermal/step_wise.c
+++ b/drivers/thermal/step_wise.c
@@ -163,9 +163,6 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip)
 		dev_dbg(&instance->cdev->device, "old_target=%d, target=%d\n",
 					old_target, (int)instance->target);
 
-		if (instance->initialized && old_target == instance->target)
-			continue;
-
 		/* Activate a passive thermal instance */
 		if (old_target == THERMAL_NO_TARGET &&
 			instance->target != THERMAL_NO_TARGET)


### PR DESCRIPTION
fix fan speedup on temp. increase, v4.9, compaq 6735b, similar as the acer issue in https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/thermal/step_wise.c?h=v3.12.74&id=bca746037a308e2fbe742248d34635f07be2bfd9