### PR TITLE
    x86, ioapic: Reserve less space for IOAPICs

### DIFF
--- a/arch/x86/include/asm/apicdef.h
+++ b/arch/x86/include/asm/apicdef.h
@@ -16,7 +16,7 @@
  * This is the IO-APIC register space as specified
  * by Intel docs:
  */
-#define IO_APIC_SLOT_SIZE		1024
+#define IO_APIC_SLOT_SIZE		68
 
 #define	APIC_ID		0x20
 


### PR DESCRIPTION
commit 212e155b14636edec1aebe9a003a727e1250b242
Author: Bjorn Helgaas <bhelgaas@google.com>
Date:   Tue Aug 23 11:56:26 2011 -0600

    x86, ioapic: Reserve less space for IOAPICs
    
    Previously we reserved 1024 bytes, but that's more space than the IOAPIC
    consumes, and it can cause conflicts with nearby devices.
